### PR TITLE
solving asynchronization issue within convert function

### DIFF
--- a/src/elevenlabs/text_to_speech/client.py
+++ b/src/elevenlabs/text_to_speech/client.py
@@ -372,7 +372,7 @@ class AsyncTextToSpeechClient:
             _request["voice_settings"] = voice_settings
         if pronunciation_dictionary_locators is not OMIT:
             _request["pronunciation_dictionary_locators"] = pronunciation_dictionary_locators
-        async with self._client_wrapper.httpx_client.stream(
+        async with await self._client_wrapper.httpx_client.stream(
             "POST",
             urllib.parse.urljoin(
                 f"{self._client_wrapper.get_base_url()}/", f"v1/text-to-speech/{jsonable_encoder(voice_id)}"


### PR DESCRIPTION
The "convert" function had an issue while using the "AsyncElevenlabs" class in streaming. The issue appeared as follows:

"coroutine object doesn't support the asynchronous context manager protocol"

The issue was solved by adding .await within the "convert" function in the "AsyncTextToSpeechClient" class.